### PR TITLE
fix: harden layer IPC compatibility and resume paused playback

### DIFF
--- a/docs/development/api-reference.md
+++ b/docs/development/api-reference.md
@@ -209,6 +209,7 @@ ipc_send_response(client_fd, "STATUS: playing video /path/to/video.mp4\n");
 | `stop` | None | `OK` | Stop gSlapper (exits) |
 | `query` | None | `STATUS: <state> <type> <path>` | Get current wallpaper state |
 | `change <path>` | File path | `OK` or `OK: transition started` | Change wallpaper |
+| `layer <name>` | `background`, `bottom`, `top`, `overlay` | `OK` or `ERROR` | Change Wayland layer at runtime |
 | `set-transition <type>` | `none` or `fade` | `OK` or `ERROR` | Set transition effect |
 | `set-transition-duration <secs>` | 0.0-5.0 seconds | `OK` or `ERROR` | Set transition duration |
 | `get-transition` | None | `TRANSITION: <type> <enabled> <duration>` | Query transition settings |

--- a/docs/user-guide/ipc-control.md
+++ b/docs/user-guide/ipc-control.md
@@ -74,6 +74,22 @@ echo "change /path/to/new/video.mp4" | nc -U /tmp/gslapper.sock
 
 **Response:** `OK: transition started` (if transitions enabled) or `OK`
 
+### `layer <name>`
+
+Switch gSlapper to a different Wayland layer at runtime.
+
+Supported layer names: `background`, `bottom`, `top`, `overlay`.
+
+```bash
+echo "layer top" | nc -U /tmp/gslapper.sock
+echo "layer background" | nc -U /tmp/gslapper.sock
+```
+
+**Response:** `OK` or `ERROR: <message>`
+
+!!! note "Compositor support"
+    Dynamic layer switching requires layer-shell protocol support for `set_layer` (v2+). On older compositors, this command returns an error.
+
 ### `stop`
 
 Stop gSlapper.
@@ -163,8 +179,11 @@ case "$1" in
         echo "set-transition fade" | nc -U "$SOCKET"
         echo "set-transition-duration 2.0" | nc -U "$SOCKET"
         ;;
+    layer)
+        echo "layer ${2:-top}" | nc -U "$SOCKET"
+        ;;
     *)
-        echo "Usage: $0 {pause|resume|next|status|transition}"
+        echo "Usage: $0 {pause|resume|next|status|transition|layer [background|bottom|top|overlay]}"
         exit 1
         ;;
 esac

--- a/src/main.c
+++ b/src/main.c
@@ -1616,6 +1616,9 @@ static void *monitor_pauselist(void *_) {
             list_paused = 0;
             if (halt_info.is_paused)
                 halt_info.is_paused -= 1;
+            // CHANGED 2026-02-21 04:30 - Resume pipeline when pauselist condition clears - Problem: playback could stay paused indefinitely after watched process exits
+            if (!halt_info.is_paused && pipeline)
+                gst_element_set_state(pipeline, GST_STATE_PLAYING);
         }
 
         pthread_sleep(1);
@@ -1661,6 +1664,9 @@ static void *handle_auto_pause(void *_) {
             }
             if (halt_info.is_paused)
                 halt_info.is_paused -= 1;
+            // CHANGED 2026-02-21 04:30 - Resume pipeline after auto-pause hidden state clears - Problem: wallpaper could remain frozen after becoming visible again
+            if (!halt_info.is_paused && pipeline)
+                gst_element_set_state(pipeline, GST_STATE_PLAYING);
         }
     }
     pthread_exit(NULL);


### PR DESCRIPTION
## Summary
- guard the new IPC `layer` command behind layer-shell v2 support and negotiate bind version as `min(advertised, 2)` to avoid protocol-version regressions
- document the `layer` command in IPC help and docs so it is discoverable and includes compositor support notes
- fix pause lifecycle by resuming the GStreamer pipeline when `pauselist` and `auto-pause` conditions clear (addresses freeze behavior seen in issue #9 scenarios)

## Test plan
- [x] Build with `ninja -C build`
- [x] Verify IPC help includes `layer <name>`
- [x] Verify docs include `layer` in user guide and API reference
- [ ] Manual runtime check: `echo "layer top" | nc -U /tmp/gslapper.sock` on compositor supporting layer-shell v2+
- [ ] Manual runtime check: trigger pauselist/auto-pause and verify playback resumes when condition clears

Fixes #9

---

> [!NOTE]
> **Medium Risk**
> Touches Wayland protocol version negotiation and live surface updates plus GStreamer state transitions; regressions could affect compositor compatibility or playback state, but changes are localized and add explicit guards.
> 
> **Overview**
> Prevents the IPC `layer` command from issuing unsupported requests by **checking the bound layer-shell protocol version** and returning a clear error when dynamic `set_layer` isn’t available; also binds `zwlr_layer_shell_v1` using `min(advertised, 2)` and makes layer name parsing case-insensitive.
> 
> Fixes pause lifecycle edge cases by **resuming the GStreamer pipeline** when `pauselist` or `--auto-pause` conditions clear, avoiding wallpapers staying frozen/paused.
> 
> Updates IPC documentation and help text to include the `layer <name>` command, usage examples, and a compositor-support note about requiring layer-shell v2+.