### PR TITLE
perf: upload frames through double-buffered PBOs (NVIDIA)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -503,13 +503,22 @@ static void upload_frame_to_texture(GLuint texture, const void *data, gsize size
 
     if (!texture_manager.pbo_disabled) {
         if (texture_manager.pbo[0] == 0) {
-            while (glGetError() != GL_NO_ERROR); // clear stale errors
-            glGenBuffers(2, texture_manager.pbo);
-            if (texture_manager.pbo[0] == 0 || glGetError() != GL_NO_ERROR) {
+            // CHANGED 2026-07-09 - Gate PBO path to NVIDIA - Problem: on Mesa/Intel UMA the direct upload path is already efficient and the PBO round-trip measurably regressed throughput (4K60 on UHD 620: 1872 rendered of 3792 captured)
+            const char *gl_vendor = (const char *)glGetString(GL_VENDOR);
+            if (!gl_vendor || !strstr(gl_vendor, "NVIDIA")) {
                 texture_manager.pbo_disabled = TRUE;
-                cflp_warning("PBO creation failed, using direct texture uploads");
-            } else if (VERBOSE) {
-                cflp_info("Using double-buffered PBO texture uploads");
+                if (VERBOSE)
+                    cflp_info("GL vendor '%s': using direct texture uploads (PBO path is NVIDIA-only)",
+                              gl_vendor ? gl_vendor : "unknown");
+            } else {
+                while (glGetError() != GL_NO_ERROR); // clear stale errors
+                glGenBuffers(2, texture_manager.pbo);
+                if (texture_manager.pbo[0] == 0 || glGetError() != GL_NO_ERROR) {
+                    texture_manager.pbo_disabled = TRUE;
+                    cflp_warning("PBO creation failed, using direct texture uploads");
+                } else if (VERBOSE) {
+                    cflp_info("Using double-buffered PBO texture uploads");
+                }
             }
         }
         if (!texture_manager.pbo_disabled) {
@@ -521,16 +530,23 @@ static void upload_frame_to_texture(GLuint texture, const void *data, gsize size
                                          GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
             if (dst) {
                 memcpy(dst, data, size);
-                glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
-                glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height,
-                                GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-                glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
-                glBindTexture(GL_TEXTURE_2D, 0);
-                return;
+                // CHANGED 2026-07-09 - Check glUnmapBuffer result - Problem: GL_FALSE means the buffer store was lost and its contents are undefined; uploading from it would display corruption
+                if (glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER) == GL_TRUE) {
+                    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height,
+                                    GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+                    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+                    glBindTexture(GL_TEXTURE_2D, 0);
+                    return;
+                }
+                // Buffer store lost (rare, e.g. after a mode switch); upload
+                // this frame directly from client memory instead
+                if (VERBOSE)
+                    cflp_warning("glUnmapBuffer reported lost buffer store, uploading frame directly");
+            } else {
+                texture_manager.pbo_disabled = TRUE;
+                cflp_warning("PBO map failed, falling back to direct texture uploads");
             }
             glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
-            texture_manager.pbo_disabled = TRUE;
-            cflp_warning("PBO map failed, falling back to direct texture uploads");
         }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -96,6 +96,10 @@ static struct {
     int current_width;
     int current_height;
     gboolean initialized;
+    // CHANGED 2026-07-08 - Double-buffered pixel unpack buffers for async uploads - Problem: glTexSubImage2D from client memory blocks the render thread every frame
+    GLuint pbo[2];
+    int pbo_index;
+    gboolean pbo_disabled; // fall back to direct uploads permanently on failure
 } texture_manager = {0};
 
 // Video frame data for thread-safe texture updates
@@ -444,6 +448,12 @@ static void cleanup_texture_manager() {
         if (VERBOSE)
             cflp_info("Cleaned up texture manager");
     }
+    // CHANGED 2026-07-08 - Delete upload PBOs - Problem: new GL objects need cleanup
+    if (texture_manager.pbo[0] != 0) {
+        glDeleteBuffers(2, texture_manager.pbo);
+        texture_manager.pbo[0] = 0;
+        texture_manager.pbo[1] = 0;
+    }
 }
 
 // Get texture for current dimensions with smart allocation
@@ -484,6 +494,49 @@ static GLuint get_texture_for_dimensions(int width, int height) {
     }
     
     return texture_manager.texture;
+}
+
+// CHANGED 2026-07-08 - Upload via ping-ponged PBOs so the driver DMAs frame N-1 while we write frame N - Problem: synchronous client-memory uploads stalled rendering
+// Must be called with a current EGL context; binds and restores its own GL state.
+static void upload_frame_to_texture(GLuint texture, const void *data, gsize size, int width, int height) {
+    glBindTexture(GL_TEXTURE_2D, texture);
+
+    if (!texture_manager.pbo_disabled) {
+        if (texture_manager.pbo[0] == 0) {
+            while (glGetError() != GL_NO_ERROR); // clear stale errors
+            glGenBuffers(2, texture_manager.pbo);
+            if (texture_manager.pbo[0] == 0 || glGetError() != GL_NO_ERROR) {
+                texture_manager.pbo_disabled = TRUE;
+                cflp_warning("PBO creation failed, using direct texture uploads");
+            } else if (VERBOSE) {
+                cflp_info("Using double-buffered PBO texture uploads");
+            }
+        }
+        if (!texture_manager.pbo_disabled) {
+            texture_manager.pbo_index ^= 1;
+            glBindBuffer(GL_PIXEL_UNPACK_BUFFER, texture_manager.pbo[texture_manager.pbo_index]);
+            // Orphan the buffer so mapping never syncs against in-flight DMA
+            glBufferData(GL_PIXEL_UNPACK_BUFFER, size, NULL, GL_STREAM_DRAW);
+            void *dst = glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, size,
+                                         GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
+            if (dst) {
+                memcpy(dst, data, size);
+                glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+                glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height,
+                                GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+                glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+                glBindTexture(GL_TEXTURE_2D, 0);
+                return;
+            }
+            glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+            texture_manager.pbo_disabled = TRUE;
+            cflp_warning("PBO map failed, falling back to direct texture uploads");
+        }
+    }
+
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height,
+                    GL_RGBA, GL_UNSIGNED_BYTE, data);
+    glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 static void exit_slapper(int reason) {
@@ -1072,12 +1125,10 @@ static void render(struct display_output *output) {
         if (err_before != GL_NO_ERROR && VERBOSE)
             cflp_info("OpenGL error before texture update: 0x%x", err_before);
         
-        // Update texture data with efficient sub-image update
+        // CHANGED 2026-07-08 - Route upload through PBO helper - Problem: direct upload stalled the render thread
         GLuint current_texture = get_texture_for_dimensions(video_frame_data.width, video_frame_data.height);
-        glBindTexture(GL_TEXTURE_2D, current_texture);
-        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, video_frame_data.width, video_frame_data.height, 
-                        GL_RGBA, GL_UNSIGNED_BYTE, video_frame_data.data);
-        glBindTexture(GL_TEXTURE_2D, 0);
+        upload_frame_to_texture(current_texture, video_frame_data.data, video_frame_data.size,
+                                video_frame_data.width, video_frame_data.height);
         
         // Check OpenGL error after texture update
         GLenum err_after = glGetError();


### PR DESCRIPTION
Supersedes #14, which GitHub auto-closed when its base branch (`perf/frame-path`) was deleted on merging #13. Same branch, same two commits; see #14 for the original discussion and audit thread.

## Summary

Routes texture uploads through two ping-ponged `GL_PIXEL_UNPACK_BUFFER`s so DMA for frame N−1 overlaps CPU writes for frame N, instead of blocking in `glTexSubImage2D`.

**NVIDIA-only by design:** bare-metal audit on Intel UHD 620 (Mesa) showed the PBO round-trip regressing 4K60 throughput (1872 rendered of 3792 captured), while RTX 4060 showed ~6% less CPU per frame at full 60fps. The path enables only when `GL_VENDOR` reports NVIDIA; Mesa and everything else keep the direct upload path unchanged. `glUnmapBuffer` lost-store results fall back to a direct upload for that frame; PBO creation/map failure disables the path permanently.

## Status

**Hold for non-NVIDIA benchmark**: pending a UHD 620 re-run confirming the vendor gate makes this branch match #13's numbers on Intel (the PBO code no longer executes there).