### PR TITLE
Fix restore and IPC state controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ builddir/
 .wrap-db/
 meson-logs/
 meson-private/
+compile_commands.json
 
 # Compiled binaries
 gslapper
@@ -29,8 +30,19 @@ gslapper-holder
 *~
 *.swp
 *.swo
+*.tmp
+*.temp
+*.orig
+*.rej
+*.save
 .DS_Store
 Thumbs.db
+
+# Python/cache files used by docs and local tooling
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
 
 # IDE files
 .vscode/
@@ -57,6 +69,8 @@ adorable-black-kitten*
 # Backup files
 *.bak
 *.backup
+*.backup.*
+*.fixed
 
 # Generated protocol files
 *-protocol.c

--- a/docs/development/api-reference.md
+++ b/docs/development/api-reference.md
@@ -206,7 +206,8 @@ ipc_send_response(client_fd, "STATUS: playing video /path/to/video.mp4\n");
 |---------|------------|----------|-------------|
 | `pause` | None | `OK` | Pause video playback |
 | `resume` | None | `OK` | Resume paused playback |
-| `stop` | None | `OK` | Stop gSlapper (exits) |
+| `stop`, `quit` | None | `OK` | Stop gSlapper (exits) |
+| `save-state` | None | `OK: state saved` | Save current wallpaper state |
 | `query` | None | `STATUS: <state> <type> <path>` | Get current wallpaper state |
 | `change <path>` | File path | `OK` or `OK: transition started` | Change wallpaper |
 | `layer <name>` | `background`, `bottom`, `top`, `overlay` | `OK` or `ERROR` | Change Wayland layer at runtime |

--- a/docs/superpowers/handoffs/2026-07-08-restore-ipc-state-compat.md
+++ b/docs/superpowers/handoffs/2026-07-08-restore-ipc-state-compat.md
@@ -1,0 +1,152 @@
+# Handover: Restore, IPC, and Consumer Compatibility
+
+Date: 2026-07-08
+Branch: `fix/restore-ipc-state-compat`
+PR: https://github.com/Nomadcxx/gSlapper/pull/17
+Implementation commit: `85d232d`
+
+## Scope
+
+This session focused on pre-release correctness around restore/state behavior and compatibility with projects that invoke gSlapper as a backend. The work intentionally stayed narrow: command-line restore handling, IPC command behavior, state file durability, documentation alignment, and consumer smoke checks.
+
+## Changes Made
+
+### Restore CLI
+
+- `gslapper --restore` now accepts the documented restore shape without requiring a normal wallpaper positional argument.
+- `gslapper --restore [output]` is now shown in `--help`.
+- Wildcard/all-output restore selectors (`*`, `all`, `All`, `ALL`) restore from the default `state.txt` instead of an output-specific `state-_.txt`.
+- `--state-file PATH` is now honored during restore.
+- If restore fails and no fallback wallpaper was supplied, gSlapper exits with a clear error instead of falling through ambiguously.
+- Restore with a fallback wallpaper remains supported: `gslapper --restore <output> <fallback>`.
+
+### State Saving
+
+- State saving for wildcard/all-output runs now records the logical selector while still using the default state file path.
+- The atomic writer in `src/state.c` now uses a unique temporary file (`mkstemp`) instead of a fixed `<state>.tmp` path.
+- This fixes a real local failure where an abandoned `state.txt.tmp` permanently blocked all future saves with `Failed to create temp state file`.
+- Temp files are still created in the same directory and renamed into place, preserving atomic replacement semantics.
+- Temp state file permissions are explicitly set to `0600`.
+
+### IPC
+
+- Added IPC `quit` as an alias for `stop`.
+- Added the documented IPC `save-state` command.
+- Updated IPC help text to list `stop, quit` and `save-state`.
+- Fixed IPC response fd ownership:
+  - The client thread now duplicates the accepted client fd for each queued command.
+  - The main loop owns that duplicate until it sends the response.
+  - The queued command cleanup closes the response fd.
+- This fixes the observed behavior where `socat` received an empty response and gSlapper logged `Failed to send IPC response: Bad file descriptor`.
+- Multiple newline-delimited commands on one socket connection were tested and still work.
+
+### Documentation
+
+- Updated `docs/user-guide/ipc-control.md`:
+  - Documents `stop` / `quit`.
+  - Documents IPC `save-state`.
+- Updated `docs/development/api-reference.md`:
+  - Adds `quit` beside `stop`.
+  - Adds `save-state`.
+
+## Consumer Compatibility Assessment
+
+### Waytrogen
+
+Repository checked: https://github.com/nikolaizombie1/waytrogen
+
+Current Waytrogen gSlapper integration invokes gSlapper approximately as:
+
+```bash
+gslapper -I /tmp/gslapper.sock [-p|-s] -o "<scale loop no-audio additional>" -f <monitor|*> <image>
+```
+
+It also tries to stop an existing gSlapper instance with:
+
+```bash
+echo quit | socat - UNIX-CONNECT:/tmp/gslapper.sock
+```
+
+and falls back to `pkill -9 gslapper`.
+
+Assessment:
+
+- The launch shape remains compatible.
+- The new IPC `quit` alias directly supports Waytrogen's graceful shutdown path.
+- Before this fix, Waytrogen would rely on its forced-kill fallback because gSlapper did not handle `quit`.
+- After this fix, `quit` returns `OK` and exits cleanly in local live IPC testing.
+
+### Waypaper
+
+Repository checked: https://github.com/anufrievroman/waypaper
+
+Current Waypaper gSlapper integration invokes gSlapper approximately as:
+
+```bash
+gslapper --fork -o "loop <fill-mode> [no-audio] [user-options]" <monitor|*> <path>
+```
+
+It does not use gSlapper IPC for normal operation. It stops gSlapper with process killing (`killall gslapper` for all outputs or monitor-pattern matching for a specific output).
+
+Assessment:
+
+- The launch shape remains compatible.
+- Local smoke tests started Waypaper-shaped commands with these option variants: `panscan=1.0`, `original`, `stretch`, and `fill`.
+- No parser, startup, or immediate runtime errors were observed for those command shapes.
+- There is one semantic mismatch worth noting: Waypaper maps its UI `fill` option to gSlapper `panscan=1.0`. In current gSlapper semantics, `panscan=1.0` behaves like contain/fit, while gSlapper `fill` is cover/crop. This is not a gSlapper release blocker, but it is a good future upstream fix for Waypaper's backend mapping.
+
+## Local Verification
+
+Ran on this laptop against the rebuilt local binary:
+
+```bash
+ninja -C build
+tests/test_basic.sh
+```
+
+Result:
+
+- Build passed.
+- Basic integration tests passed: 16 passed, 0 failed.
+- Existing warning remains in `output_description`: discards `const` qualifier. This was left out of scope.
+
+Live checks performed:
+
+- `gslapper --restore --state-file /tmp/gslapper-definitely-missing`
+  - Exits `1` with explicit missing-state/fallback error.
+- `gslapper --restore '*'`
+  - No longer fails with the old positional-argument error.
+- IPC over Unix socket:
+  - `query` returns status.
+  - `save-state` returns `OK: state saved`.
+  - `help` lists the expected commands.
+  - `quit` returns `OK` and exits.
+  - Multi-command socket input returned responses correctly.
+- Waypaper-shaped launch commands:
+  - `loop panscan=1.0 no-audio`
+  - `loop original no-audio`
+  - `loop stretch no-audio`
+  - `loop fill no-audio`
+
+The rebuilt binary was installed to the active user path:
+
+```bash
+/home/nomadx/.local/bin/gslapper
+```
+
+The installed user-local binary hash matched `build/gslapper` after installation.
+
+## Process Hygiene
+
+Extra smoke-test gSlapper processes were cleaned up. The only gSlapper process intentionally left running was the existing sysc-greet wallpaper instance:
+
+```bash
+gslapper -f -I /tmp/sysc-greet-wallpaper.sock * /usr/share/sysc-greet/wallpapers/sysc-greet-dark.png
+```
+
+## Follow-Ups
+
+- Review PR #17 on a second environment before merging.
+- Consider an upstream Waypaper issue or PR to map Waypaper UI `fill` to gSlapper `fill` instead of `panscan=1.0`.
+- Consider a small follow-up cleanup for old backup files under `src/`, because they pollute search results with stale `clappie` and old IPC/state behavior.
+- Consider separately fixing the existing `output_description` `const` warning.

--- a/docs/user-guide/ipc-control.md
+++ b/docs/user-guide/ipc-control.md
@@ -90,15 +90,26 @@ echo "layer background" | nc -U /tmp/gslapper.sock
 !!! note "Compositor support"
     Dynamic layer switching requires layer-shell protocol support for `set_layer` (v2+). On older compositors, this command returns an error.
 
-### `stop`
+### `stop` / `quit`
 
 Stop gSlapper.
 
 ```bash
 echo "stop" | nc -U /tmp/gslapper.sock
+echo "quit" | nc -U /tmp/gslapper.sock
 ```
 
 **Response:** `OK` (gSlapper exits)
+
+### `save-state`
+
+Save the current wallpaper state without stopping gSlapper.
+
+```bash
+echo "save-state" | nc -U /tmp/gslapper.sock
+```
+
+**Response:** `OK: state saved`
 
 ### `set-transition <type>`
 

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -53,19 +53,27 @@ static bool ipc_validate_input(const char *input, int client_fd) {
 }
 
 static void ipc_queue_command_internal(const char *cmd_line, int client_fd) {
+    int response_fd = dup(client_fd);
+    if (response_fd < 0) {
+        cflp_error("Failed to duplicate IPC client FD: %s", strerror(errno));
+        return;
+    }
+
     ipc_command_t *cmd = calloc(1, sizeof(ipc_command_t));
     if (!cmd) {
         cflp_error("Failed to allocate IPC command");
+        close(response_fd);
         return;
     }
 
     cmd->cmd_line = strdup(cmd_line);
     if (!cmd->cmd_line) {
         cflp_error("Failed to allocate IPC command string");
+        close(response_fd);
         free(cmd);
         return;
     }
-    cmd->client_fd = client_fd;
+    cmd->client_fd = response_fd;
     cmd->next = NULL;
 
     pthread_mutex_lock(&ipc_queue_mutex);

--- a/src/main.c
+++ b/src/main.c
@@ -2200,8 +2200,13 @@ static void execute_ipc_commands(void) {
         }
         else if (strcmp(cmd_name, "save-state") == 0) {
             // CHANGED 2026-07-08 - Expose documented state save over IPC - Problem: docs advertised save-state but the IPC dispatcher did not handle it
-            save_current_state();
-            ipc_send_response(cmd->client_fd, "OK: state saved\n");
+            // CHANGED 2026-07-09 - Report when saving is disabled - Problem: with --no-save-state, save_current_state() silently no-ops and the OK response was a lie
+            if (!save_state_on_exit) {
+                ipc_send_response(cmd->client_fd, "ERROR: state saving disabled (--no-save-state)\n");
+            } else {
+                save_current_state();
+                ipc_send_response(cmd->client_fd, "OK: state saved\n");
+            }
         }
         else if (strcmp(cmd_name, "preload") == 0) {
             if (!arg || strlen(arg) == 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -275,6 +275,7 @@ static int restore_from_state(const char *path);
 static void restore_video_position(void);
 static void notify_systemd_ready(void);
 static void notify_systemd_stopping(void);
+static bool is_all_outputs_selector(const char *monitor);
 
 // Cleanup function
 static void exit_cleanup() {
@@ -1388,7 +1389,9 @@ static void save_current_state(void) {
     
     // Get output name from first configured output
     char *current_output = NULL;
-    if (global_state && !wl_list_empty(&global_state->outputs)) {
+    if (global_state && is_all_outputs_selector(global_state->monitor)) {
+        state.output = global_state->monitor;
+    } else if (global_state && !wl_list_empty(&global_state->outputs)) {
         struct display_output *output;
         wl_list_for_each(output, &global_state->outputs, link) {
             if (output->name) {
@@ -1468,9 +1471,10 @@ static void save_current_state(void) {
 // Restore state (sets existing globals)
 static int restore_from_state(const char *path) {
     char *state_path = NULL;
+    const char *loaded_path = path;
     if (!path) {
-        // Try to get output-specific state file first
-        if (global_state && global_state->monitor) {
+        // Try to get output-specific state file first; wildcard restore uses default state.txt.
+        if (global_state && global_state->monitor && !is_all_outputs_selector(global_state->monitor)) {
             state_path = get_state_file_path(global_state->monitor);
         }
         // Fall back to default if output-specific not found
@@ -1482,6 +1486,7 @@ static int restore_from_state(const char *path) {
             return -1;
         }
         path = state_path;
+        loaded_path = path;
     }
     
     struct wallpaper_state state = {0};
@@ -1522,6 +1527,8 @@ static int restore_from_state(const char *path) {
             if (global_state->monitor) free(global_state->monitor);
             global_state->monitor = strdup(state.output);
             pthread_mutex_unlock(&state_mutex);
+        } else if (global_state && !global_state->monitor) {
+            global_state->monitor = strdup("*");
         }
         
         // FIXED: Store restore position in global (not static inside function)
@@ -1535,14 +1542,22 @@ static int restore_from_state(const char *path) {
     
     free_wallpaper_state(&state);
     
+    if (VERBOSE)
+        cflp_info("State restored successfully from %s", loaded_path);
+
     // Free state_path if we allocated it
     if (state_path) {
         free(state_path);
     }
-    
-    if (VERBOSE)
-        cflp_info("State restored successfully from %s", path);
     return 0;
+}
+
+static bool is_all_outputs_selector(const char *monitor) {
+    return monitor &&
+           (strcmp(monitor, "*") == 0 ||
+            strcmp(monitor, "ALL") == 0 ||
+            strcmp(monitor, "All") == 0 ||
+            strcmp(monitor, "all") == 0);
 }
 
 // Systemd readiness notification
@@ -2176,12 +2191,17 @@ static void execute_ipc_commands(void) {
                 }
             }
         }
-        else if (strcmp(cmd_name, "stop") == 0) {
+        else if (strcmp(cmd_name, "stop") == 0 || strcmp(cmd_name, "quit") == 0) {
             ipc_send_response(cmd->client_fd, "OK\n");
             // Close write side to ensure response is flushed
             shutdown(cmd->client_fd, SHUT_WR);
             usleep(50000);  // Delay to ensure response is sent before exit
             exit_slapper(EXIT_SUCCESS);
+        }
+        else if (strcmp(cmd_name, "save-state") == 0) {
+            // CHANGED 2026-07-08 - Expose documented state save over IPC - Problem: docs advertised save-state but the IPC dispatcher did not handle it
+            save_current_state();
+            ipc_send_response(cmd->client_fd, "OK: state saved\n");
         }
         else if (strcmp(cmd_name, "preload") == 0) {
             if (!arg || strlen(arg) == 0) {
@@ -2316,7 +2336,8 @@ static void execute_ipc_commands(void) {
                 "  query                    Get current status\n"
                 "  change <path>            Change wallpaper\n"
                 "  layer <name>             Set layer (background|bottom|top|overlay)\n"
-                "  stop                     Stop gslapper\n"
+                "  stop, quit               Stop gslapper\n"
+                "  save-state               Save current wallpaper state\n"
                 "  preload <path>           Preload image into cache\n"
                 "  unload <path|all|unused> Remove from cache\n"
                 "  cache-list               List cached images\n"
@@ -2333,6 +2354,8 @@ static void execute_ipc_commands(void) {
         }
 
         // Cleanup command
+        if (cmd->client_fd >= 0)
+            close(cmd->client_fd);
         free(cmd->cmd_line);
         free(cmd);
     }
@@ -3483,6 +3506,7 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
 
     const char *usage =
         "Usage: slapper [options] <output> <url|path filename>\n"
+        "       slapper --restore [output]\n"
         "\n"
         "Example: slapper -vs -o \"no-audio loop\" DP-2 /path/to/video\n"
         "\n"
@@ -3500,6 +3524,11 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
         "--ipc-socket   -I PATH          Enable IPC control via Unix socket\n"
         "--transition-type TYPE          Transition effect (fade, none, default: none)\n"
         "--transition-duration SECS      Transition duration in seconds (default: 0.5)\n"
+        "--systemd      -S              Enable systemd readiness notifications\n"
+        "--restore      -R              Restore wallpaper from saved state\n"
+        "--save-state                   Save current state and exit\n"
+        "--state-file PATH              Use a custom state file path\n"
+        "--no-save-state                Disable automatic state saving on exit\n"
         "--cache-size MB                 Image cache size in MB (default: 256, 0 to disable)\n"
         "\n"
         "Scaling modes (use with -o):\n"
@@ -3650,8 +3679,23 @@ static void parse_command_line(int argc, char **argv, struct wl_state *state) {
     if (VERBOSE)
         cflp_info("Verbose Level %i enabled", VERBOSE);
 
-    // Need at least a output and file or playlist file
-    if (optind+1 >= argc) {
+    int remaining_args = argc - optind;
+
+    if (restore_flag) {
+        if (remaining_args > 2) {
+            cflp_error("Too many args passed. Restore accepts optional output and optional fallback wallpaper");
+            fprintf(stderr, "%s", usage);
+            exit(EXIT_FAILURE);
+        }
+        if (remaining_args >= 1)
+            state->monitor = strdup(argv[optind]);
+        if (remaining_args == 2)
+            video_path = strdup(argv[optind+1]);
+        return;
+    }
+
+    // Need at least an output and file or playlist file for normal startup.
+    if (remaining_args < 2) {
         cflp_error("Not enough args passed. Please set output and url|path filename");
         fprintf(stderr, "%s", usage);
         exit(EXIT_FAILURE);
@@ -3712,12 +3756,16 @@ int main(int argc, char **argv) {
     
     // Handle --restore flag (restore state before initialization)
     if (restore_flag) {
-        if (restore_from_state(NULL) == 0) {
+        if (restore_from_state(state_file_path) == 0) {
             if (VERBOSE)
                 cflp_info("State restored, continuing with restored wallpaper");
         } else {
+            if (!video_path) {
+                cflp_error("No state file found or restore failed, and no fallback wallpaper was provided");
+                exit(EXIT_FAILURE);
+            }
             if (VERBOSE)
-                cflp_info("No state file found or restore failed, continuing normally");
+                cflp_info("No state file found or restore failed, continuing with fallback wallpaper");
         }
     }
     
@@ -3898,4 +3946,3 @@ int main(int argc, char **argv) {
 
     return EXIT_SUCCESS;
 }
-

--- a/src/state.c
+++ b/src/state.c
@@ -98,14 +98,24 @@ char *get_state_file_path(const char *output_name) {
 int save_state_file(const char *path, const struct wallpaper_state *state) {
     if (!path || !state || !state->path) return -1;
     
-    // Use atomic write: write to temp file, then rename (atomic on POSIX)
+    // Use atomic write: write to a unique temp file, then rename (atomic on POSIX).
+    // A fixed temp name can be left behind after a crash and permanently block saves.
     char temp_path[MAX_PATH_LEN];
-    snprintf(temp_path, sizeof(temp_path), "%s.tmp", path);
-    
-    // Open temp file with exclusive lock (use O_CREAT|O_EXCL for atomic lock file)
-    int fd = open(temp_path, O_WRONLY | O_CREAT | O_EXCL | O_TRUNC, 0600);
+    int written = snprintf(temp_path, sizeof(temp_path), "%s.tmp.XXXXXX", path);
+    if (written < 0 || (size_t)written >= sizeof(temp_path)) {
+        cflp_error("State file path too long");
+        return -1;
+    }
+
+    int fd = mkstemp(temp_path);
     if (fd < 0) {
         cflp_error("Failed to create temp state file: %s", strerror(errno));
+        return -1;
+    }
+    if (fchmod(fd, 0600) != 0) {
+        cflp_error("Failed to set temp state file permissions: %s", strerror(errno));
+        close(fd);
+        unlink(temp_path);
         return -1;
     }
     


### PR DESCRIPTION
## Summary
- allow `gslapper --restore` to run with no positional wallpaper path, including wildcard/default state restore
- add IPC `quit` alias and `save-state` command wiring/docs
- keep IPC response fds alive until the main loop sends replies
- use unique atomic state temp files so stale `.tmp` files do not permanently block saves

## Compatibility checked
- Waypaper current `main` invokes `gslapper --fork -o "loop <scale> [no-audio] ..." <monitor|*> <path>`; equivalent launch shapes parse and start locally
- Waytrogen current `main` sends `quit` over `/tmp/gslapper.sock`; `quit` now returns `OK` and exits cleanly

## Tested
- `ninja -C build`
- `tests/test_basic.sh`
- live IPC: `query`, `save-state`, `help`, and `quit` over one Unix socket connection return responses
- restore missing state exits 1 with an explicit error
- wildcard restore no longer hits the old positional-argument failure
- Waypaper-shaped launches: `panscan=1.0`, `original`, `stretch`, and `fill` options all started without parser/runtime startup errors

## Notes
- Existing warning remains: `output_description` discards `const` qualifier. Left out of scope.
- Waypaper currently maps its UI `fill` option to gSlapper `panscan=1.0`; that starts correctly but behaves like contain/fit rather than cover/crop in current gSlapper semantics.