### PR TITLE
nix: fix missing GST_PLUGIN_SYSTEM_PATH_1_0 wrapper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
               gst_all_1.gst-plugins-good
               systemd
               wayland-scanner
+              makeWrapper
             ];
             buildInputs = with pkgs; [
               meson
@@ -46,6 +47,21 @@
             ];
             pname = "gslapper";
             version = "1.5.0";
+
+            postFixup = ''
+              wrapProgram $out/bin/gslapper \
+                --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${
+                  pkgs.lib.makeSearchPath "lib/gstreamer-1.0" (
+                    with pkgs.gst_all_1;
+                    [
+                      gstreamer.out
+                      gst-plugins-base
+                      gst-plugins-good
+                      gst-plugins-bad
+                    ]
+                  )
+                }"
+            '';
           };
           default = gslapper;
         };


### PR DESCRIPTION
Installing gslapper via a NixOS system module (e.g. \`environment.systemPackages\`) rather than through \`nix develop\` fails at runtime with:

\`\`\`
[-] Failed to create playbin element
\`\`\`

The derivation links against GStreamer fine but never wraps the binary with \`GST_PLUGIN_SYSTEM_PATH_1_0\`, so the plugin registry is empty outside a dev shell where mkShell's setup hook happens to export it. This adds a \`postFixup\`/\`wrapProgram\` step so the installed binary works standalone. One thing worth flagging for review: \`gst_all_1.gstreamer\` is a multi-output derivation and needs \`.out\` pinned explicitly (\`gstreamer.out\`), referencing it bare resolves to the \`bin\` output, which has none of the core plugins (including \`typefind\`) and produces a confusing downstream error.