### PR TITLE
Make IPC pause and resume idempotent

### DIFF
--- a/docs-site/content/docs/development/api-reference.md
+++ b/docs-site/content/docs/development/api-reference.md
@@ -207,8 +207,8 @@ ipc_send_response(client_fd, "STATUS: playing video /path/to/video.mp4\n");
 
 | Command | Parameters | Response | Description |
 |---------|------------|----------|-------------|
-| `pause` | None | `OK` | Pause video playback |
-| `resume` | None | `OK` | Resume paused playback |
+| `pause` | None | `OK` | Pause video playback (idempotent; repeats are no-ops) |
+| `resume` | None | `OK` | Release the IPC pause (idempotent; does not override auto-pause or pauselist holds) |
 | `stop`, `quit` | None | `OK` | Stop gSlapper (exits) |
 | `save-state` | None | `OK: state saved` | Save current wallpaper state |
 | `query` | None | `STATUS: <state> <type> <path>` | Get current wallpaper state |

--- a/docs-site/content/docs/user-guide/ipc-control.mdx
+++ b/docs-site/content/docs/user-guide/ipc-control.mdx
@@ -49,15 +49,23 @@ echo "pause" | nc -U /tmp/gslapper.sock
 
 **Response:** `OK`
 
+`pause` is idempotent: repeating it on an already-paused instance answers `OK` and changes nothing. However many times you send `pause`, one `resume` restores playback.
+
 ### `resume`
 
-Resume paused playback.
+Resume playback that was paused through IPC.
 
 ```bash
 echo "resume" | nc -U /tmp/gslapper.sock
 ```
 
 **Response:** `OK`
+
+`resume` is idempotent and releases only the pause set through IPC. If playback is paused by `--auto-pause` or the pauselist, `resume` answers `OK` without overriding that hold; playback continues once the hold clears.
+
+<Callout type="info" title="Multi-monitor controllers">
+Front ends that drive one gSlapper instance per output can send the same `pause` or `resume` to every instance, including instances already in the requested state. Redundant commands are safe no-ops.
+</Callout>
 
 ### `query`
 
@@ -68,6 +76,8 @@ echo "query" | nc -U /tmp/gslapper.sock
 ```
 
 **Response:** `STATUS: playing image /path/to/wallpaper.jpg` or `STATUS: paused video /path/to/video.mp4`
+
+The `paused` state reflects every pause source: IPC `pause`, `--auto-pause`, and the pauselist.
 
 ### `change <path>`
 

--- a/src/main.c
+++ b/src/main.c
@@ -174,6 +174,9 @@ static bool restore_paused = false;
 // Whether IPC currently holds a pause contribution in halt_info.is_paused.
 // IPC pause/resume are idempotent: repeated pause commands must not stack
 // extra increments that would each require their own resume.
+// Written only from the main loop (execute_ipc_commands and
+// reload_image_pipeline); the auto-pause and pauselist threads adjust
+// halt_info.is_paused for their own holds but never touch this flag.
 static bool ipc_paused = false;
 
 // Cache configuration
@@ -2590,6 +2593,14 @@ static bool reload_image_pipeline(const char *new_path) {
         }
         gst_object_unref(pipeline);
         pipeline = NULL;
+    }
+
+    // The pipeline the IPC pause applied to is gone; release the IPC hold so
+    // an image change starts fresh like a video change does through its
+    // process restart. Holds owned by auto-pause or the pauselist stay.
+    if (ipc_paused) {
+        ipc_paused = false;
+        if (halt_info.is_paused > 0) halt_info.is_paused--;
     }
 
     // Reset image capture flag

--- a/src/main.c
+++ b/src/main.c
@@ -171,6 +171,11 @@ static pthread_mutex_t state_mutex = PTHREAD_MUTEX_INITIALIZER;
 static double restore_position = 0.0;
 static bool restore_paused = false;
 
+// Whether IPC currently holds a pause contribution in halt_info.is_paused.
+// IPC pause/resume are idempotent: repeated pause commands must not stack
+// extra increments that would each require their own resume.
+static bool ipc_paused = false;
+
 // Cache configuration
 static size_t cache_size_mb = DEFAULT_CACHE_SIZE_MB;
 
@@ -2019,7 +2024,12 @@ static void execute_ipc_commands(void) {
 
         // Dispatch commands
         if (strcmp(cmd_name, "pause") == 0) {
-            if (pipeline) {
+            if (!pipeline) {
+                ipc_send_response(cmd->client_fd, "ERROR: no pipeline\n");
+            } else if (ipc_paused) {
+                // Already paused through IPC; repeating the command is a no-op
+                ipc_send_response(cmd->client_fd, "OK\n");
+            } else {
                 GstStateChangeReturn ret = gst_element_set_state(pipeline, GST_STATE_PAUSED);
                 if (ret == GST_STATE_CHANGE_FAILURE) {
                     ipc_send_response(cmd->client_fd, "ERROR: failed to pause\n");
@@ -2031,19 +2041,25 @@ static void execute_ipc_commands(void) {
                             ipc_send_response(cmd->client_fd, "ERROR: failed to pause\n");
                         } else {
                             halt_info.is_paused++;
+                            ipc_paused = true;
                             ipc_send_response(cmd->client_fd, "OK\n");
                         }
                     } else {
                         halt_info.is_paused++;
+                        ipc_paused = true;
                         ipc_send_response(cmd->client_fd, "OK\n");
                     }
                 }
-            } else {
-                ipc_send_response(cmd->client_fd, "ERROR: no pipeline\n");
             }
         }
         else if (strcmp(cmd_name, "resume") == 0) {
-            if (pipeline) {
+            if (!pipeline) {
+                ipc_send_response(cmd->client_fd, "ERROR: no pipeline\n");
+            } else if (!ipc_paused) {
+                // IPC holds no pause contribution; do not release pauses owned
+                // by auto-pause or the pauselist monitor
+                ipc_send_response(cmd->client_fd, "OK\n");
+            } else {
                 GstStateChangeReturn ret = gst_element_set_state(pipeline, GST_STATE_PLAYING);
                 if (ret == GST_STATE_CHANGE_FAILURE) {
                     ipc_send_response(cmd->client_fd, "ERROR: failed to resume\n");
@@ -2055,15 +2071,15 @@ static void execute_ipc_commands(void) {
                             ipc_send_response(cmd->client_fd, "ERROR: failed to resume\n");
                         } else {
                             if (halt_info.is_paused > 0) halt_info.is_paused--;
+                            ipc_paused = false;
                             ipc_send_response(cmd->client_fd, "OK\n");
                         }
                     } else {
                         if (halt_info.is_paused > 0) halt_info.is_paused--;
+                        ipc_paused = false;
                         ipc_send_response(cmd->client_fd, "OK\n");
                     }
                 }
-            } else {
-                ipc_send_response(cmd->client_fd, "ERROR: no pipeline\n");
             }
         }
         else if (strcmp(cmd_name, "query") == 0) {


### PR DESCRIPTION
## Summary

IPC `pause` incremented `halt_info.is_paused` on every command, so a client that paused an already-paused instance needed two `resume` commands before `query` reported playing again. Multi-monitor front ends that converge several instances to one state hit this: after a pause-all on mixed states, the already-paused monitor stayed stuck through resume-all. Found while wiring Waypaper's gSlapper backend onto IPC (anufrievroman/waypaper#303).

The fix tracks the IPC contribution in a single `ipc_paused` flag:

- A repeated `pause` answers `OK` without touching the counter or the pipeline.
- A `resume` without an IPC-held pause answers `OK` and releases nothing, so IPC can no longer steal a pause owned by `--auto-pause` or the pauselist monitor.
- Non-redundant commands behave exactly as before.

## Compatibility

- Waytrogen gates its Pause and Resume buttons on the queried state (`can_pause`/`can_resume` in `src/changers/gslapper.rs`), so it never sends redundant commands and sees no behavior change.
- Clients that did stack pauses now recover with a single resume.
- Auto-pause and pauselist nesting still works: an IPC pause on top of an auto-pause hold requires both releases, as before.

## Testing

Built and exercised against a headless sway output over a real IPC socket:

- resume while playing: no-op `OK`, still playing
- pause, pause, resume: playing after one resume
- triple pause, single resume: playing
