### PR TITLE
fix: unblock signals after registering handlers

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -3729,10 +3729,24 @@ int main(int argc, char **argv) {
     mtrace();
 
     // CHANGED 2025-12-25 - Added SIGHUP handler for config reload - Problem: Need runtime config reload support
+    // CHANGED 2026-07-19 - Unblock signals after registering handlers - Problem: when gSlapper is spawned by a
+    // Wayland compositor (e.g. cagebreak) that uses wl_event_loop_add_signal, the compositor blocks SIGTERM
+    // via sigprocmask(SIG_BLOCK) so it can deliver the signal through signalfd. That blocked mask is inherited
+    // by exec'd children. signal() installs a handler but does not unblock the signal, so SIGTERM stays
+    // blocked and pkill/SIGTERM from session teardown or IPC restart paths never reaches the handler.
+    // gSlapper handles these signals itself via handle_signal(), so unblock them explicitly.
     signal(SIGINT, handle_signal);
     signal(SIGQUIT, handle_signal);
     signal(SIGTERM, handle_signal);
     signal(SIGHUP, handle_signal);
+
+    sigset_t unblock_set;
+    sigemptyset(&unblock_set);
+    sigaddset(&unblock_set, SIGINT);
+    sigaddset(&unblock_set, SIGQUIT);
+    sigaddset(&unblock_set, SIGTERM);
+    sigaddset(&unblock_set, SIGHUP);
+    sigprocmask(SIG_UNBLOCK, &unblock_set, NULL);
 
     check_paper_processes();
 


### PR DESCRIPTION
## Problem

gSlapper registers `SIGINT`, `SIGQUIT`, `SIGTERM`, and `SIGHUP` handlers via `signal()` but never ensures those signals are unblocked in the process mask. `signal()` installs a handler but does **not** unblock the signal. If the parent process blocked any of these signals, the blocked mask is inherited by exec'd children and persists indefinitely.

## Root cause

Wayland compositors that use `wl_event_loop_add_signal()` (libwayland-server) call `sigprocmask(SIG_BLOCK, &mask, NULL)` to block the signal so it can be delivered through `signalfd` instead of the default handler. Cagebreak does this for `SIGTERM` at `cagebreak.c:391`:

```c
sigterm_source = wl_event_loop_add_signal(event_loop, SIGTERM, handle_signal, &server);
```

Which internally does (libwayland `event-loop.c`):

```c
sigemptyset(&mask);
sigaddset(&mask, signal_number);
source->base.fd = signalfd(-1, &mask, SFD_CLOEXEC | SFD_NONBLOCK);
sigprocmask(SIG_BLOCK, &mask, NULL);
```

When cagebreak execs a child (e.g. `sysc-greet --wallpaper-daemon` via the config `exec` line), the child can inherit this blocked `SIGTERM` mask. `sysc-greet` then execs `gslapper -f ...`, and gSlapper's fork child inherits it too. gSlapper calls `signal(SIGTERM, handle_signal)` which sets the handler but does **not** unblock the signal, so `SIGTERM` stays blocked forever.

## Observed impact

gSlapper spawned by cagebreak's greeter session inherited a blocked `SIGTERM`. When `sysc-greet`'s wallpaper-restart fallback ran `pkill -f gslapper` (which sends `SIGTERM`), the signal went into the pending queue but was never delivered. The process survived as an orphaned zombie with no Wayland compositor to render to, holding the IPC socket path and preventing clean restarts.

Evidence from a live system (greeter user, uid 932):

```
$ ps -o pid,user,stat,etime,args -p 1971
  PID USER     STAT  ELAPSED COMMAND
 1971 greeter  Sl    20:00  gslapper -f -I /tmp/sysc-greet-wallpaper.sock * /usr/share/sysc-greet/wallpapers/sysc-greet-eldritch.png

$ grep SigBlk /proc/1971/status
SigBlk:	0000000000004000    # bit 14 = signal 15 = SIGTERM blocked

$ grep SigCgt /proc/1971/status
SigCgt:	0000000180004007    # SIGTERM handler installed but signal blocked
```

`pkill -f gslapper` had no effect on this process. Only `SIGKILL` could kill it.

## Fix

Call `sigprocmask(SIG_UNBLOCK, ...)` for all four handled signals immediately after registering the handlers. This guarantees the signals reach `handle_signal()` regardless of the inherited mask.

```c
signal(SIGINT, handle_signal);
signal(SIGQUIT, handle_signal);
signal(SIGTERM, handle_signal);
signal(SIGHUP, handle_signal);

sigset_t unblock_set;
sigemptyset(&unblock_set);
sigaddset(&unblock_set, SIGINT);
sigaddset(&unblock_set, SIGQUIT);
sigaddset(&unblock_set, SIGTERM);
sigaddset(&unblock_set, SIGHUP);
sigprocmask(SIG_UNBLOCK, &unblock_set, NULL);
```

## Verification

Built and tested locally. Simulated the cagebreak signal-mask inheritance by blocking `SIGTERM` in the parent, then fork+exec'ing gSlapper:

**Before fix** (installed `/usr/bin/gslapper` 1.5.1, unfixed): child inherited `SigBlk: 0x4000` (SIGTERM blocked), survived `SIGTERM`, required `SIGKILL`.

**After fix** (`build/gslapper` with this patch): child has `SigBlk: 0x10000` (SIGCHLD only, SIGTERM unblocked), dies cleanly from `SIGTERM`.

```
$ /tmp/test_fix
Parent: SIGTERM blocked. Now forking gslapper...
Child gslapper PID: 49465
  SigBlk:	0000000000010000    # SIGTERM NOT blocked
  SigCgt:	0000000000010002

Sending SIGTERM to child PID 49465...
PASS: Child exited after SIGTERM
```

## Scope

This fix is narrow: it only unblocks the four signals gSlapper already handles. It does not change handler behavior, cleanup logic, or any other signal handling. The `exit_cleanup()` SEGV on signal delivery (a separate async-signal-safety bug in `handle_signal` calling non-async-signal-safe `exit_cleanup` from inside a signal handler) is out of scope for this PR and will be filed separately.

## Related

- Issue #21 (GIF wallpapers fail to load via `decodebin`) filed separately.
- The `exit_cleanup` SEGV crash (observed in production coredump at greeter session teardown) is a distinct bug: `handle_signal` calls `exit_cleanup` from inside a signal handler, which races with GStreamer streaming threads during `g_object_unref(pipeline)`. That needs a separate fix where the signal handler sets a flag and the main `poll()` loop performs cleanup.
