### PR TITLE
fix: GIF wallpapers decode via gdkpixbufdec and play animated via the video pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Full documentation available at: https://nomadcxx.github.io/gSlapper/
 ## Features
 
 - Play videos (MP4, MKV, WebM) and images (JPEG, PNG, WebP, GIF)
+- Animated GIF playback with correct frame timing and looping (requires gst-libav; shows the first frame statically without it)
 - Fade transitions between images
 - Multi-monitor support
 - IPC control via Unix socket (pause, resume, change wallpaper)

--- a/src/main.c
+++ b/src/main.c
@@ -158,6 +158,13 @@ static bool stretch_mode = false;  // Stretch to fill without maintaining aspect
 static bool fill_mode = false;       // Fill screen maintaining aspect ratio (crops excess)
 static bool is_image_mode = false;   // True if displaying static image vs video
 static gint64 gif_loop_start_us = 0; // Monotonic time the current GIF loop iteration started
+// CHANGED 2026-07-20 - Snapshot GIF-ness and expose a shutdown flag to the events thread - Problem:
+// the GStreamer events thread runs with cancellation disabled, so exit_cleanup's pthread_cancel never
+// stops it. It must not read video_path (freed by exit_cleanup) or sleep/seek against a pipeline being
+// torn down. video_is_gif is set once at startup (video changes restart the process, so it never goes
+// stale); shutting_down tells the events thread to stop touching the pipeline.
+static bool video_is_gif = false;    // True when the wallpaper is a GIF playing via the video pipeline
+static volatile sig_atomic_t shutting_down = 0;
 static bool image_frame_captured = false;  // True once image frame is decoded
 
 // State management for systemd service
@@ -290,6 +297,11 @@ static bool is_all_outputs_selector(const char *monitor);
 
 // Cleanup function
 static void exit_cleanup() {
+
+    // Tell the events thread to stop sleeping/seeking against the pipeline.
+    // It cannot be cancelled (it runs with cancellation disabled), so it must
+    // observe this flag before we free video_path and unref the pipeline.
+    shutting_down = 1;
 
     // Notify systemd that we're stopping
     notify_systemd_stopping();
@@ -1942,8 +1954,8 @@ static gboolean bus_callback(GstBus *bus, GstMessage *msg, gpointer data) {
             // CHANGED 2026-07-20 - GIFs loop via plain flush seeks - Problem: avdemux_gif mishandles
             // non-flushing segment seeks; after the first loop every buffer arrives late, sync stops
             // throttling, and the GIF plays at decode speed (~700 loops in 20s observed)
-            if (pipeline) {
-                GstSeekFlags eos_loop_flags = is_gif_file(video_path)
+            if (pipeline && !shutting_down) {
+                GstSeekFlags eos_loop_flags = video_is_gif
                     ? GST_SEEK_FLAG_FLUSH
                     : (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_SEGMENT);
                 if (!gst_element_seek_simple(pipeline, GST_FORMAT_TIME, eos_loop_flags, 0)) {
@@ -1964,19 +1976,28 @@ static gboolean bus_callback(GstBus *bus, GstMessage *msg, gpointer data) {
             // queued frames, so wait out the remaining display time before flushing or the loop runs fast.
             // Regular videos keep the gapless non-flush seek; avdemux_gif also never posts EOS with
             // playbin3, so EOS-based looping is not an option.
-            if (pipeline && is_gif_file(video_path)) {
+            if (pipeline && video_is_gif) {
                 gint64 duration = 0;
                 if (gst_element_query_duration(pipeline, GST_FORMAT_TIME, &duration) && duration > 0) {
                     gint64 remaining_us = duration / 1000 - (g_get_monotonic_time() - gif_loop_start_us);
-                    if (remaining_us > 0 && remaining_us < 30 * G_USEC_PER_SEC)
-                        g_usleep(remaining_us);
+                    if (remaining_us > 30 * G_USEC_PER_SEC)
+                        remaining_us = 0;
+                    // Sleep in short chunks so shutdown is not held up and the
+                    // pipeline is never touched after exit_cleanup starts
+                    while (remaining_us > 0 && !shutting_down) {
+                        gint64 chunk = remaining_us < 50000 ? remaining_us : 50000;
+                        g_usleep(chunk);
+                        remaining_us -= chunk;
+                    }
                 }
+                if (shutting_down)
+                    break;
                 gif_loop_start_us = g_get_monotonic_time();
                 if (!gst_element_seek_simple(pipeline, GST_FORMAT_TIME,
                                            GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_SEGMENT, 0)) {
                     cflp_warning("GIF loop seek failed");
                 }
-            } else if (pipeline) {
+            } else if (pipeline && !shutting_down) {
                 if (!gst_element_seek_simple(pipeline, GST_FORMAT_TIME,
                                            GST_SEEK_FLAG_SEGMENT, 0)) {
                     cflp_warning("Segment seek failed for seamless loop");
@@ -3983,6 +4004,7 @@ int main(int argc, char **argv) {
         // Detect if input is a static image or video. GIFs count as video
         // when a GIF video decoder is available so they play animated.
         is_image_mode = is_static_image_path(video_path);
+        video_is_gif = !is_image_mode && is_gif_file(video_path);
 
         if (is_image_mode) {
             // Default to fill mode for images (unless user specified otherwise)

--- a/src/main.c
+++ b/src/main.c
@@ -157,6 +157,7 @@ static float panscan_value = 1.0f;  // Default to full size (no scaling)
 static bool stretch_mode = false;  // Stretch to fill without maintaining aspect ratio
 static bool fill_mode = false;       // Fill screen maintaining aspect ratio (crops excess)
 static bool is_image_mode = false;   // True if displaying static image vs video
+static gint64 gif_loop_start_us = 0; // Monotonic time the current GIF loop iteration started
 static bool image_frame_captured = false;  // True once image frame is decoded
 
 // State management for systemd service
@@ -270,6 +271,8 @@ static GLuint get_texture_for_dimensions(int width, int height);
 static GLuint create_shader_program();
 static GLuint create_transition_shader_program();
 static bool is_image_file(const char *path);
+static bool is_gif_file(const char *path);
+static bool is_static_image_path(const char *path);
 static bool should_use_transition(const char *new_path);
 static void start_transition(const char *new_path);
 static void update_transition(void);
@@ -747,8 +750,8 @@ static bool should_use_transition(const char *new_path) {
         return false;
     }
     
-    // Only transition between images (not videos)
-    if (!is_image_mode || !is_image_file(new_path)) {
+    // Only transition between static images (not videos or animated GIFs)
+    if (!is_image_mode || !is_static_image_path(new_path)) {
         return false;
     }
     
@@ -1916,9 +1919,14 @@ static gboolean bus_callback(GstBus *bus, GstMessage *msg, gpointer data) {
             if (VERBOSE)
                 cflp_info("End of stream reached - fallback loop method");
             // Fallback: if we get EOS instead of SEGMENT_DONE, still loop
+            // CHANGED 2026-07-20 - GIFs loop via plain flush seeks - Problem: avdemux_gif mishandles
+            // non-flushing segment seeks; after the first loop every buffer arrives late, sync stops
+            // throttling, and the GIF plays at decode speed (~700 loops in 20s observed)
             if (pipeline) {
-                if (!gst_element_seek_simple(pipeline, GST_FORMAT_TIME, 
-                                           GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_SEGMENT, 0)) {
+                GstSeekFlags eos_loop_flags = is_gif_file(video_path)
+                    ? GST_SEEK_FLAG_FLUSH
+                    : (GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_SEGMENT);
+                if (!gst_element_seek_simple(pipeline, GST_FORMAT_TIME, eos_loop_flags, 0)) {
                     cflp_warning("EOS fallback seek failed");
                 }
             }
@@ -1928,8 +1936,28 @@ static gboolean bus_callback(GstBus *bus, GstMessage *msg, gpointer data) {
                 cflp_info("Segment done - seamless loop restart");
             // CHANGED 2025-09-07 - Use segment-based seamless looping per GStreamer best practices
             // Problem: EOS-based seeking causes playback gaps, segment seeks provide seamless transitions
-            if (pipeline) {
-                if (!gst_element_seek_simple(pipeline, GST_FORMAT_TIME, 
+            // CHANGED 2026-07-20 - GIFs loop with a delayed flushing segment seek - Problem: avdemux_gif
+            // mishandles non-flushing segment seeks: after the first loop every buffer arrives late, sync
+            // stops throttling, and the GIF plays at decode speed (~700 loops in 20s observed). The flush
+            // resets running time so frame delays are honored each loop. SEGMENT_DONE is posted when the
+            // decoder finishes the segment, which for short GIFs is well before the sink has displayed the
+            // queued frames, so wait out the remaining display time before flushing or the loop runs fast.
+            // Regular videos keep the gapless non-flush seek; avdemux_gif also never posts EOS with
+            // playbin3, so EOS-based looping is not an option.
+            if (pipeline && is_gif_file(video_path)) {
+                gint64 duration = 0;
+                if (gst_element_query_duration(pipeline, GST_FORMAT_TIME, &duration) && duration > 0) {
+                    gint64 remaining_us = duration / 1000 - (g_get_monotonic_time() - gif_loop_start_us);
+                    if (remaining_us > 0 && remaining_us < 30 * G_USEC_PER_SEC)
+                        g_usleep(remaining_us);
+                }
+                gif_loop_start_us = g_get_monotonic_time();
+                if (!gst_element_seek_simple(pipeline, GST_FORMAT_TIME,
+                                           GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_SEGMENT, 0)) {
+                    cflp_warning("GIF loop seek failed");
+                }
+            } else if (pipeline) {
+                if (!gst_element_seek_simple(pipeline, GST_FORMAT_TIME,
                                            GST_SEEK_FLAG_SEGMENT, 0)) {
                     cflp_warning("Segment seek failed for seamless loop");
                     // Fallback to regular seek
@@ -1957,9 +1985,10 @@ static gboolean bus_callback(GstBus *bus, GstMessage *msg, gpointer data) {
                     if (!segment_initialized) {
                         if (VERBOSE)
                             cflp_info("Setting up seamless segment-based looping");
-                        
+                        gif_loop_start_us = g_get_monotonic_time();
+
                         // Perform initial seek to enable segment looping
-                        if (!gst_element_seek(pipeline, 1.0, GST_FORMAT_TIME, 
+                        if (!gst_element_seek(pipeline, 1.0, GST_FORMAT_TIME,
                                             GST_SEEK_FLAG_SEGMENT,
                                             GST_SEEK_TYPE_SET, 0,
                                             GST_SEEK_TYPE_NONE, GST_CLOCK_TIME_NONE)) {
@@ -2137,8 +2166,8 @@ static void execute_ipc_commands(void) {
                         if (VERBOSE)
                             cflp_info("IPC: Change command completed");
                     } else {
-                        // No transition - check if this is an image (can reload directly)
-                        if (is_image_mode && is_image_file(arg)) {
+                        // No transition - check if this is a static image (can reload directly)
+                        if (is_image_mode && is_static_image_path(arg)) {
                             // For images, reload pipeline directly without restart
                             if (reload_image_pipeline(arg)) {
                                 ipc_send_response(cmd->client_fd, "OK\n");
@@ -2562,6 +2591,37 @@ static bool is_gif_file(const char *path) {
     return strcmp(ext_lower, ".gif") == 0;
 }
 
+// CHANGED 2026-07-20 - Play GIFs through the video pipeline when possible - Problem: the image pipeline
+// captures a single frame, so animated GIFs rendered as static images. A GIF video decoder (avdec_gif
+// from gst-libav) lets the normal video path play them animated with seamless looping.
+static bool gif_video_decoder_available(void) {
+    static int cached = -1;
+    if (cached == -1) {
+        gst_init(NULL, NULL);
+        GstCaps *gif_caps = gst_caps_new_empty_simple("image/gif");
+        // DECODABLE (decoders + demuxers + parsers) matches what decodebin
+        // autoplugs: gst-libav handles GIF as avdemux_gif ! avdec_gif, where
+        // only the demuxer's sink pad advertises image/gif.
+        GList *decoders = gst_element_factory_list_get_elements(
+            GST_ELEMENT_FACTORY_TYPE_DECODABLE, GST_RANK_MARGINAL);
+        GList *gif_decoders = gst_element_factory_list_filter(decoders, gif_caps, GST_PAD_SINK, FALSE);
+        cached = (gif_decoders != NULL);
+        gst_plugin_feature_list_free(gif_decoders);
+        gst_plugin_feature_list_free(decoders);
+        gst_caps_unref(gif_caps);
+    }
+    return cached;
+}
+
+// Whether path should display through the static image pipeline. GIFs go
+// through the video pipeline when a GIF video decoder is installed; without
+// one they fall back to a static first frame via gdkpixbufdec.
+static bool is_static_image_path(const char *path) {
+    if (!is_image_file(path)) return false;
+    if (is_gif_file(path) && gif_video_decoder_available()) return false;
+    return true;
+}
+
 // Callback for decodebin dynamic pad linking (image pipeline)
 static void on_decodebin_pad_added(GstElement *decodebin, GstPad *pad, gpointer data) {
     GstElement *videoconvert = (GstElement *)data;
@@ -2638,7 +2698,7 @@ static bool reload_image_pipeline(const char *new_path) {
     }
 
     // Update is_image_mode
-    is_image_mode = is_image_file(new_path);
+    is_image_mode = is_static_image_path(new_path);
 
     // Build the new image pipeline inline (don't call init_image_pipeline to avoid exit on error)
     char resolved_path[PATH_MAX];
@@ -2680,6 +2740,8 @@ static bool reload_image_pipeline(const char *new_path) {
     // Create pipeline elements
     // CHANGED 2026-07-20 - Select GIF decoder explicitly - Problem: decodebin has no image/gif decoder path
     bool use_pixbuf_decoder = is_gif_file(resolved_path);
+    if (use_pixbuf_decoder)
+        cflp_warning("No GIF video decoder found (install gst-libav for animation); displaying first frame only");
     GstElement *filesrc = gst_element_factory_make("filesrc", "filesrc");
     GstElement *decoder = gst_element_factory_make(
         use_pixbuf_decoder ? "gdkpixbufdec" : "decodebin", "imagedec");
@@ -2884,6 +2946,8 @@ static void init_image_pipeline(void) {
     // Create pipeline elements
     // CHANGED 2026-07-20 - Select GIF decoder explicitly - Problem: decodebin has no image/gif decoder path
     bool use_pixbuf_decoder = is_gif_file(resolved_path);
+    if (use_pixbuf_decoder)
+        cflp_warning("No GIF video decoder found (install gst-libav for animation); displaying first frame only");
     GstElement *filesrc = gst_element_factory_make("filesrc", "filesrc");
     GstElement *decoder = gst_element_factory_make(
         use_pixbuf_decoder ? "gdkpixbufdec" : "decodebin", "imagedec");
@@ -3890,8 +3954,9 @@ int main(int argc, char **argv) {
         if (VERBOSE)
             cflp_success("EGL initialized");
 
-        // Detect if input is image or video
-        is_image_mode = is_image_file(video_path);
+        // Detect if input is a static image or video. GIFs count as video
+        // when a GIF video decoder is available so they play animated.
+        is_image_mode = is_static_image_path(video_path);
 
         if (is_image_mode) {
             // Default to fill mode for images (unless user specified otherwise)

--- a/src/main.c
+++ b/src/main.c
@@ -2542,6 +2542,26 @@ static bool is_image_file(const char *path) {
     return false;
 }
 
+// CHANGED 2026-07-20 - Route GIF through gdkpixbufdec - Problem: decodebin picks decoders by matching
+// typefind caps against sink pad templates, and gdkpixbufdec's template does not advertise image/gif
+// even though gdk-pixbuf decodes GIF fine. No other element provides an image/gif decoder on a standard
+// install, so decodebin fails with "missing a plug-in" for every GIF. Linking filesrc straight into
+// gdkpixbufdec skips caps-based selection and lets gdk-pixbuf sniff the format itself. Other image
+// formats keep decodebin so their dedicated decoders (pngdec, jpegdec, webpdec) stay in use.
+static bool is_gif_file(const char *path) {
+    if (!path) return false;
+
+    const char *ext = strrchr(path, '.');
+    if (!ext) return false;
+
+    char ext_lower[16] = {0};
+    for (int i = 0; ext[i] && i < 15; i++) {
+        ext_lower[i] = (ext[i] >= 'A' && ext[i] <= 'Z') ? ext[i] + 32 : ext[i];
+    }
+
+    return strcmp(ext_lower, ".gif") == 0;
+}
+
 // Callback for decodebin dynamic pad linking (image pipeline)
 static void on_decodebin_pad_added(GstElement *decodebin, GstPad *pad, gpointer data) {
     GstElement *videoconvert = (GstElement *)data;
@@ -2658,12 +2678,17 @@ static bool reload_image_pipeline(const char *new_path) {
         cflp_info("Loading new image: %s", resolved_path);
 
     // Create pipeline elements
+    // CHANGED 2026-07-20 - Select GIF decoder explicitly - Problem: decodebin has no image/gif decoder path
+    bool use_pixbuf_decoder = is_gif_file(resolved_path);
     GstElement *filesrc = gst_element_factory_make("filesrc", "filesrc");
-    GstElement *decodebin = gst_element_factory_make("decodebin", "decodebin");
+    GstElement *decoder = gst_element_factory_make(
+        use_pixbuf_decoder ? "gdkpixbufdec" : "decodebin", "imagedec");
     GstElement *videoconvert = gst_element_factory_make("videoconvert", "videoconvert");
     GstElement *appsink = gst_element_factory_make("appsink", "appsink");
 
-    if (!filesrc || !decodebin || !videoconvert || !appsink) {
+    if (!filesrc || !decoder || !videoconvert || !appsink) {
+        if (use_pixbuf_decoder && !decoder)
+            cflp_error("gdkpixbufdec unavailable (install gst-plugins-good)");
         cflp_error("Failed to create image pipeline elements");
         cancel_transition();
         return false;
@@ -2692,11 +2717,11 @@ static bool reload_image_pipeline(const char *new_path) {
     gst_caps_unref(caps);
 
     // Add elements to pipeline
-    gst_bin_add_many(GST_BIN(pipeline), filesrc, decodebin, videoconvert, appsink, NULL);
+    gst_bin_add_many(GST_BIN(pipeline), filesrc, decoder, videoconvert, appsink, NULL);
 
-    // Link filesrc to decodebin
-    if (!gst_element_link(filesrc, decodebin)) {
-        cflp_error("Failed to link filesrc to decodebin");
+    // Link filesrc to decoder
+    if (!gst_element_link(filesrc, decoder)) {
+        cflp_error("Failed to link filesrc to image decoder");
         gst_object_unref(pipeline);
         pipeline = NULL;
         cancel_transition();
@@ -2712,8 +2737,18 @@ static bool reload_image_pipeline(const char *new_path) {
         return false;
     }
 
-    // Connect decodebin's dynamic pad to videoconvert
-    g_signal_connect(decodebin, "pad-added", G_CALLBACK(on_decodebin_pad_added), videoconvert);
+    // gdkpixbufdec has static pads and links directly; decodebin needs dynamic pad linking
+    if (use_pixbuf_decoder) {
+        if (!gst_element_link(decoder, videoconvert)) {
+            cflp_error("Failed to link gdkpixbufdec to videoconvert");
+            gst_object_unref(pipeline);
+            pipeline = NULL;
+            cancel_transition();
+            return false;
+        }
+    } else {
+        g_signal_connect(decoder, "pad-added", G_CALLBACK(on_decodebin_pad_added), videoconvert);
+    }
 
     // Set up buffer probe on appsink
     GstPad *sink_pad = gst_element_get_static_pad(appsink, "sink");
@@ -2841,18 +2876,23 @@ static void init_image_pipeline(void) {
     // Initialize GStreamer if not already done
     gst_init(NULL, NULL);
 
-    // Build simple image pipeline: filesrc ! decodebin ! videoconvert ! appsink
+    // Build simple image pipeline: filesrc ! (decodebin | gdkpixbufdec) ! videoconvert ! appsink
 
     if (VERBOSE)
         cflp_info("Loading image: %s", resolved_path);
 
     // Create pipeline elements
+    // CHANGED 2026-07-20 - Select GIF decoder explicitly - Problem: decodebin has no image/gif decoder path
+    bool use_pixbuf_decoder = is_gif_file(resolved_path);
     GstElement *filesrc = gst_element_factory_make("filesrc", "filesrc");
-    GstElement *decodebin = gst_element_factory_make("decodebin", "decodebin");
+    GstElement *decoder = gst_element_factory_make(
+        use_pixbuf_decoder ? "gdkpixbufdec" : "decodebin", "imagedec");
     GstElement *videoconvert = gst_element_factory_make("videoconvert", "videoconvert");
     GstElement *appsink = gst_element_factory_make("appsink", "appsink");
 
-    if (!filesrc || !decodebin || !videoconvert || !appsink) {
+    if (!filesrc || !decoder || !videoconvert || !appsink) {
+        if (use_pixbuf_decoder && !decoder)
+            cflp_error("gdkpixbufdec unavailable (install gst-plugins-good)");
         cflp_error("Failed to create image pipeline elements");
         exit_slapper(EXIT_FAILURE);
     }
@@ -2879,11 +2919,11 @@ static void init_image_pipeline(void) {
     gst_caps_unref(caps);
 
     // Add elements to pipeline
-    gst_bin_add_many(GST_BIN(pipeline), filesrc, decodebin, videoconvert, appsink, NULL);
+    gst_bin_add_many(GST_BIN(pipeline), filesrc, decoder, videoconvert, appsink, NULL);
 
-    // Link filesrc to decodebin
-    if (!gst_element_link(filesrc, decodebin)) {
-        cflp_error("Failed to link filesrc to decodebin");
+    // Link filesrc to decoder
+    if (!gst_element_link(filesrc, decoder)) {
+        cflp_error("Failed to link filesrc to image decoder");
         exit_slapper(EXIT_FAILURE);
     }
 
@@ -2893,8 +2933,15 @@ static void init_image_pipeline(void) {
         exit_slapper(EXIT_FAILURE);
     }
 
-    // Connect decodebin's dynamic pad to videoconvert
-    g_signal_connect(decodebin, "pad-added", G_CALLBACK(on_decodebin_pad_added), videoconvert);
+    // gdkpixbufdec has static pads and links directly; decodebin needs dynamic pad linking
+    if (use_pixbuf_decoder) {
+        if (!gst_element_link(decoder, videoconvert)) {
+            cflp_error("Failed to link gdkpixbufdec to videoconvert");
+            exit_slapper(EXIT_FAILURE);
+        }
+    } else {
+        g_signal_connect(decoder, "pad-added", G_CALLBACK(on_decodebin_pad_added), videoconvert);
+    }
 
     // Set up buffer probe on appsink
     GstPad *sink_pad = gst_element_get_static_pad(appsink, "sink");

--- a/tests/test_image_formats.sh
+++ b/tests/test_image_formats.sh
@@ -58,18 +58,20 @@ iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAA
 EOF
 
 # Runs gslapper with an image wallpaper for a few seconds, then SIGTERMs it.
-# Success means the image decoded (cache add logged) with no decode error.
+# Success means the file decoded with no decode error: static images log
+# "Cache added"; GIFs route through the video pipeline when gst-libav is
+# installed and log "Loaded" instead.
 test_image_decode() {
     local file="$1" label="$2" log="$WORK_DIR/$label.log"
 
     timeout -s TERM 8 stdbuf -oL -eL "$GSLAPPER" --no-save-state -v '*' "$file" > "$log" 2>&1
 
-    if grep -q "Image decode error" "$log"; then
-        fail "$label wallpaper decodes ($(grep 'Image decode error' "$log" | head -1))"
-    elif grep -q "Cache added" "$log"; then
+    if grep -qE "Image decode error|GStreamer error" "$log"; then
+        fail "$label wallpaper decodes ($(grep -E 'Image decode error|GStreamer error' "$log" | head -1))"
+    elif grep -qE "Cache added|Loaded " "$log"; then
         pass "$label wallpaper decodes"
     else
-        fail "$label wallpaper decodes (no decode error but no cache add; log tail: $(tail -3 "$log" | tr '\n' ' '))"
+        fail "$label wallpaper decodes (no decode error but no success line; log tail: $(tail -3 "$log" | tr '\n' ' '))"
     fi
 }
 

--- a/tests/test_image_formats.sh
+++ b/tests/test_image_formats.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Image format decode tests.
+# Regression test for issue #21: GIF wallpapers failed because the image
+# pipeline used decodebin, which has no image/gif decoder on a standard
+# GStreamer install. PNG is tested alongside to guard the common path.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+GSLAPPER="$PROJECT_ROOT/build/gslapper"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    echo "PASS: $1"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+fail() {
+    echo "FAIL: $1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+skip() {
+    echo "SKIP: $1"
+}
+
+echo "=== gSlapper Image Format Tests ==="
+echo ""
+
+if [[ ! -x "$GSLAPPER" ]]; then
+    fail "gslapper binary not found at $GSLAPPER"
+    echo "Run: ninja -C build"
+    exit 1
+fi
+
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-1}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+if [[ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]; then
+    skip "No Wayland display at $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY - cannot run live decode tests"
+    exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+    pkill -9 -f "no-save-state" 2>/dev/null
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# 1x1 fixtures, embedded so the test has no external file dependencies
+base64 -d > "$WORK_DIR/test.gif" <<'EOF'
+R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
+EOF
+base64 -d > "$WORK_DIR/test.png" <<'EOF'
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==
+EOF
+
+# Runs gslapper with an image wallpaper for a few seconds, then SIGTERMs it.
+# Success means the image decoded (cache add logged) with no decode error.
+test_image_decode() {
+    local file="$1" label="$2" log="$WORK_DIR/$label.log"
+
+    timeout -s TERM 8 stdbuf -oL -eL "$GSLAPPER" --no-save-state -v '*' "$file" > "$log" 2>&1
+
+    if grep -q "Image decode error" "$log"; then
+        fail "$label wallpaper decodes ($(grep 'Image decode error' "$log" | head -1))"
+    elif grep -q "Cache added" "$log"; then
+        pass "$label wallpaper decodes"
+    else
+        fail "$label wallpaper decodes (no decode error but no cache add; log tail: $(tail -3 "$log" | tr '\n' ' '))"
+    fi
+}
+
+test_image_decode "$WORK_DIR/test.png" "PNG"
+test_image_decode "$WORK_DIR/test.gif" "GIF"
+
+echo ""
+echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed ==="
+[[ $TESTS_FAILED -eq 0 ]]


### PR DESCRIPTION
## Problem

Issue #21: GIF wallpapers fail with `Your GStreamer installation is missing a plug-in.` The image pipeline uses `decodebin`, which selects decoders by matching typefind caps against sink pad templates. `gdkpixbufdec`'s pad template does not advertise `image/gif` even though gdk-pixbuf decodes GIF fine, and no other element provides an `image/gif` decoder on a standard install. So `decodebin` reports `Missing decoder: GIF (image/gif)` for every GIF, and a saved GIF state makes the systemd `--restore` service loop on restart.

On top of that, the image pipeline captures a single frame, so even a decoded GIF would display frozen.

## Fix (two commits)

**1. Static GIF decode (`1cc815f`)** — Route `.gif` files into `gdkpixbufdec` in both `init_image_pipeline()` and `reload_image_pipeline()`. It has static pads, so `filesrc ! gdkpixbufdec` links directly and gdk-pixbuf sniffs the format from the byte stream, bypassing caps-based selection. All other formats keep `decodebin` — a full swap would regress WebP, whose `webpdec` ships in gst-plugins-bad (declared dep) while gdk-pixbuf needs the optional `webp-pixbuf-loader`.

**2. Animated playback (`77d644f`)** — When a GIF video decoder is present in the registry (`avdemux_gif`/`avdec_gif` from gst-libav), `.gif` routes through the normal video pipeline and plays animated. Without gst-libav it falls back to the static first frame with a warning. Details:

- The availability check uses `GST_ELEMENT_FACTORY_TYPE_DECODABLE` because only the libav *demuxer*'s sink pad advertises `image/gif` (`avdec_gif` sinks `image/gst-libav-gif`).
- GIF looping uses a flushing segment seek delayed by the remaining display time. `avdemux_gif` mishandles non-flushing segment seeks (every buffer arrives late after the first loop, sync stops throttling, playback runs at decode speed — ~700 loops in 20s observed) and never posts EOS under playbin3. `SEGMENT_DONE` is posted when the decoder finishes the segment, well before short GIFs finish displaying, hence the delay.
- Regular videos keep the gapless non-flush segment loop, verified unchanged.

## Verification

New regression test `tests/test_image_formats.sh` (PNG + GIF live decode): failed on GIF before, both pass after. `tests/test_basic.sh`: 16/16.

Animated playback validated against ffprobe ground truth across four GIFs (1.4s/12f, 3.96s/44f, 5.9s/59f, 60s/904f): appsink frame counts and loop periods now match each file's actual frame timing exactly (e.g. the 1.44s/12-frame GIF loops 10x in 15s with 120 frames delivered). Confirmed visually on both monitors.

## Consumer impact

Waytrogen and Waypaper pass image paths through unchanged CLI shapes; no flag, IPC, or behavior changes. GIF selections that previously crashed the restore service now work, and animate when gst-libav is installed (already listed in optdepends).

Fixes #21