### PR TITLE
fix: perform signal shutdown from the main loop, not the signal handler

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -572,7 +572,27 @@ static void exit_slapper(int reason) {
 }
 
 // CHANGED 2025-12-25 - Implemented SIGHUP reload functionality - Problem: Need config reload without restarting process
+// CHANGED 2026-07-20 - Signal handler only records the signal - Problem: handle_signal called
+// save_current_state/exit_cleanup directly from signal context. Neither is async-signal-safe
+// (file I/O, usleep, pthread_cancel, g_object_unref of the pipeline), and the handler can run
+// on any thread: production coredumps show the main thread and a GStreamer streaming thread
+// both inside exit_cleanup, double-freeing the pipeline (SEGV). SIGTERM during startup crashed
+// or hung half of local test runs. The main poll() loop, which wakes on EINTR when a signal
+// is delivered, calls process_pending_signal() to do the shutdown from normal context.
+static volatile sig_atomic_t pending_signal = 0;
+
 static void handle_signal(int signum) {
+    pending_signal = signum;
+}
+
+// Performs the shutdown work handle_signal used to do, from normal context.
+// Called from the main loop and from init/reload wait loops.
+static void process_pending_signal(void) {
+    int signum = pending_signal;
+    if (signum == 0)
+        return;
+    pending_signal = 0;
+
     if (signum == SIGHUP) {
         // SIGHUP means reload - save state and restart gracefully
         cflp_info("Received SIGHUP, saving state for reload...");
@@ -2772,6 +2792,9 @@ static bool reload_image_pipeline(const char *new_path) {
             wl_display_flush(global_state->display);
         }
         
+        // Handle shutdown signals arriving during the decode wait
+        process_pending_signal();
+
         // Short sleep to avoid busy-waiting
         g_usleep(10000);  // 10ms - balance between responsiveness and CPU usage
         waited += 10;  // Increment by sleep duration
@@ -2917,6 +2940,9 @@ static void init_image_pipeline(void) {
     int timeout_ms = 5000;
     int waited = 0;
     while (!image_frame_captured && waited < timeout_ms) {
+        // Handle shutdown signals arriving during the decode wait
+        process_pending_signal();
+
         g_usleep(10000);  // 10ms
         waited += 10;
 
@@ -3913,6 +3939,11 @@ int main(int argc, char **argv) {
         int poll_result = poll(fds, nfds, poll_timeout);
         if (poll_result == -1 && errno != EINTR)
             break;
+
+        // Handle signals recorded by handle_signal() from normal context.
+        // A delivered signal interrupts poll() with EINTR, so this runs
+        // immediately after delivery.
+        process_pending_signal();
 
 
         // If wl_display_prepare_read() was successful as 0

--- a/tests/test_signal_shutdown.sh
+++ b/tests/test_signal_shutdown.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Signal shutdown tests.
+# Regression test for the exit_cleanup SEGV: handle_signal() called
+# exit_cleanup() directly from signal context. exit_cleanup is not
+# async-signal-safe (file I/O, thread joins, g_object_unref of the
+# pipeline) and races the GStreamer streaming threads, crashing on
+# greeter session teardown in production. gslapper must exit cleanly
+# from SIGTERM no matter when the signal lands.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+GSLAPPER="$PROJECT_ROOT/build/gslapper"
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    echo "PASS: $1"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+fail() {
+    echo "FAIL: $1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+skip() {
+    echo "SKIP: $1"
+}
+
+echo "=== gSlapper Signal Shutdown Tests ==="
+echo ""
+
+if [[ ! -x "$GSLAPPER" ]]; then
+    fail "gslapper binary not found at $GSLAPPER"
+    echo "Run: ninja -C build"
+    exit 1
+fi
+
+export WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-wayland-1}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+if [[ ! -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]]; then
+    skip "No Wayland display at $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY - cannot run live signal tests"
+    exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+    pkill -9 -f "no-save-state" 2>/dev/null
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# Short test video so GStreamer streaming threads are active (the racy
+# condition from the production coredump)
+if ! gst-launch-1.0 -q videotestsrc num-buffers=150 ! vp8enc deadline=1 \
+        ! webmmux ! filesink location="$WORK_DIR/test.webm" 2>/dev/null; then
+    skip "Could not generate test video (vp8enc missing?)"
+    exit 0
+fi
+
+ITERATIONS=20
+DELAYS=(0.15 0.3 0.6 1.0)
+failures=0
+
+for i in $(seq 1 $ITERATIONS); do
+    delay=${DELAYS[$(( (i - 1) % ${#DELAYS[@]} ))]}
+
+    "$GSLAPPER" --no-save-state -o "loop" '*' "$WORK_DIR/test.webm" \
+        > "$WORK_DIR/run-$i.log" 2>&1 &
+    pid=$!
+
+    sleep "$delay"
+    # Two quick SIGTERMs: session teardown often delivers more than one
+    kill -TERM "$pid" 2>/dev/null
+    sleep 0.05
+    kill -TERM "$pid" 2>/dev/null
+
+    rc=0
+    for _ in $(seq 1 100); do
+        if ! kill -0 "$pid" 2>/dev/null; then break; fi
+        sleep 0.1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null
+        wait "$pid" 2>/dev/null
+        echo "  iteration $i (delay ${delay}s): HUNG, needed SIGKILL"
+        failures=$((failures + 1))
+        continue
+    fi
+    wait "$pid"
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
+        sig=$((rc - 128))
+        echo "  iteration $i (delay ${delay}s): exit code $rc (signal $sig)"
+        failures=$((failures + 1))
+    fi
+done
+
+if [[ $failures -eq 0 ]]; then
+    pass "SIGTERM exits cleanly across $ITERATIONS timing variations"
+else
+    fail "SIGTERM shutdown: $failures of $ITERATIONS runs crashed or hung"
+fi
+
+echo ""
+echo "=== Results: $TESTS_PASSED passed, $TESTS_FAILED failed ==="
+[[ $TESTS_FAILED -eq 0 ]]


### PR DESCRIPTION
## Problem

Issue #24: `handle_signal()` called `save_current_state()` and `exit_cleanup()` directly from signal context. Neither is async-signal-safe (file I/O, `usleep`, `pthread_cancel`, socket teardown, `g_object_unref` of the pipeline), and the handler can run on any thread. A second signal during cleanup puts two threads inside `exit_cleanup` at once, double-freeing the pipeline.

Production coredump (greeter session teardown, systemd-logind SIGTERM): main thread and a GStreamer streaming thread concurrently inside `exit_cleanup`, SEGV in `g_object_unref`. Locally, SIGTERM landing 0.15-0.3s after startup crashed (SIGABRT, core dumped) or hung **10 of 20 runs**.

## Fix

`handle_signal` now only records the signal number in a `volatile sig_atomic_t` and returns. The main `poll()` loop — which wakes with EINTR the moment a signal is delivered, so there is no added shutdown latency — calls `process_pending_signal()` to perform the save/cleanup/exit from normal context. The image-pipeline decode-wait loops check the flag too, so signals landing during init or an IPC-triggered reload are honored before the main loop starts.

Behavior is unchanged from the outside: SIGHUP still saves state and exits 0 for a systemd `--restore` restart; SIGINT/SIGTERM/SIGQUIT still save state and exit 0.

## Verification

New regression test `tests/test_signal_shutdown.sh`: 20 gslapper runs with an active video pipeline, SIGTERM delivered at cycling delays (0.15/0.3/0.6/1.0s), double-signaled 50ms apart to stress handler reentry.

- Before: 10 of 20 runs crashed (SIGABRT) or hung requiring SIGKILL.
- After: 20 of 20 exit cleanly, across two consecutive rounds.

`tests/test_basic.sh`: 16 passed, 0 failed.

## Consumer impact

This completes the signal-robustness work started in #22: #22 made SIGTERM deliverable when the parent blocked it; this PR makes acting on it crash-free. Waypaper's `killall gslapper` and sysc-greet's `pkill` fallback (sysc-greet issue #83) now get a clean save-state-and-exit instead of a coredump. Waytrogen's IPC `quit` path is untouched.

Fixes #24